### PR TITLE
Fix device service url path separator

### DIFF
--- a/api/web/src/device/service.rs
+++ b/api/web/src/device/service.rs
@@ -12,7 +12,7 @@ pub(crate) async fn update_device(
     entry: PutDeviceDtoRequest,
 ) -> Result<DeviceResponseDto> {
     let resp = reqwest::Client::new()
-        .put(base_ulr.to_string() + endpoints::DEVICE + &id.to_string())
+        .put(base_ulr.to_string() + endpoints::DEVICE + "/" + &id.to_string())
         .json(&entry)
         .send()
         .await


### PR DESCRIPTION
Add missing path separator in `update_device` URL construction to fix malformed device URLs.

The `update_device` function was concatenating `endpoints::DEVICE` directly with the device UUID, resulting in URLs like `/device<UUID>` instead of the correct `/device/<UUID>`.