### PR TITLE
Fix auth and device service port conflict

### DIFF
--- a/integration-tests/tests/test_helper.rs
+++ b/integration-tests/tests/test_helper.rs
@@ -180,7 +180,7 @@ async fn start_device_service(
 ) -> tokio::task::JoinHandle<Result<(), std::io::Error>> {
     let device_service_config = device_service::Config {
         database_url: db_url,
-        service_port: 3001,
+        service_port: 3002,
         sentry_url: String::new(),
     };
 


### PR DESCRIPTION
Resolve port conflict by changing `device_service` port from 3001 to 3002.